### PR TITLE
fix: correct 'Sucess' to 'Success' in upload success snackbar messages

### DIFF
--- a/lib/DB_Services/upload_helper.dart
+++ b/lib/DB_Services/upload_helper.dart
@@ -42,7 +42,7 @@ class UploadHelperIMGPDF {
           filename);
 
       if (result.toString() != "null") {
-        GlobalSnackBarGet().showGetSucess("Sucess", "PDF Uploaded");
+        GlobalSnackBarGet().showGetSucess("Success", "PDF Uploaded");
         pdfController.text = result.toString();
         isdone = true;
         // Loader remove
@@ -99,7 +99,7 @@ class UploadHelperIMGPDF {
         .uploadFile(File(imgController.text), "$mainpath/$subpath/", filename);
 
     if (result.toString() != "null") {
-      GlobalSnackBarGet().showGetSucess("Sucess", "Image Uploaded");
+      GlobalSnackBarGet().showGetSucess("Success", "Image Uploaded");
       imgController.text = result.toString();
       isdone = true;
 


### PR DESCRIPTION
User-facing snackbar messages shown after successful PDF and image uploads (upload_helper.dart:45,102).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the success notification title shown after PDF and image uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->